### PR TITLE
feat: basic requests to the backend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,14 @@
-import { useState } from 'react'
 import logo from './logo.svg'
 import './App.css'
+import HelloAPI from './components/HelloAPI';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>Hello Vite + React!</p>
-        <p>
-          <button type="button" onClick={() => setCount((count) => count + 1)}>
-            count is: {count}
-          </button>
-        </p>
+        <HelloAPI />
         <p>
           Edit <code>App.tsx</code> and save to test HMR updates.
         </p>

--- a/src/components/HelloAPI.tsx
+++ b/src/components/HelloAPI.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+export default () => {
+  const [message, setMessage] = useState("")
+
+  function updateMessage() {
+    fetch(import.meta.env.VITE_BACKEND_BASE_URL + "/")
+      .then(async res => setMessage(await res.text()))
+      .catch(err => console.error(err));
+  }
+
+  useEffect(updateMessage, [])
+
+  return (
+    <div>
+      <div>
+        API says: <code>{message}</code>
+      </div>
+      <button type="button" onClick={updateMessage}>
+        Refresh Message
+      </button>
+    </div>
+  )
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv extends Readonly<Record<string, string>> {
+  readonly VITE_APP_TITLE: string,
+  readonly VITE_BACKEND_BASE_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
This PR just adds a little button to make a request to the root route of the backend API, then display it. Not sure if we want Senso data on the frontend too for the tech stack demo, but if so, we can just build on this if it's usable. The idea for that should be the same, only we'll have to send a JSON body, and we'll end up with a JSON response to work with.