### PR TITLE
feat: add prettier as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-react": "^1.0.0",
+    "prettier": "^2.4.1",
     "typescript": "^4.3.2",
     "vite": "^2.6.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@types/react': ^17.0.0
   '@types/react-dom': ^17.0.0
   '@vitejs/plugin-react': ^1.0.0
+  prettier: ^2.4.1
   react: ^17.0.0
   react-dom: ^17.0.0
   typescript: ^4.3.2
@@ -17,6 +18,7 @@ devDependencies:
   '@types/react': 17.0.30
   '@types/react-dom': 17.0.9
   '@vitejs/plugin-react': 1.0.4
+  prettier: 2.4.1
   typescript: 4.4.4
   vite: 2.6.7
 
@@ -700,6 +702,12 @@ packages:
       nanoid: 3.1.30
       picocolors: 0.2.1
       source-map-js: 0.6.2
+    dev: true
+
+  /prettier/2.4.1:
+    resolution: {integrity: sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: true
 
   /react-dom/17.0.2_react@17.0.2:


### PR DESCRIPTION
This PR adds prettier as a development dependency so that editor plugins can automatically use this version instead of requiring that prettier be installed globally.