### PR TITLE
feat: only match name in addon search

### DIFF
--- a/src/entities/AddOn.ts
+++ b/src/entities/AddOn.ts
@@ -24,10 +24,6 @@ export class AddOn {
   static from(json: AddOnJSON) {
     return new AddOn(json.name, json.price, json.description);
   }
-
-  toString() {
-    return `${this.name} ${this.price} ${this.description}`;
-  }
 }
 
 export type AddOnJSON = {

--- a/src/scenes/Dashboard.tsx
+++ b/src/scenes/Dashboard.tsx
@@ -45,10 +45,8 @@ function Dashboard() {
               ? [...addOns.values()]
               : [...addOns.values()].filter(
                   (a) =>
-                    a
-                      .toString()
-                      .toLowerCase()
-                      .indexOf(searchString.toLowerCase()) !== -1
+                    a.name.toLowerCase().indexOf(searchString.toLowerCase()) !==
+                    -1
                 )
             ).map((a, i) => {
               return (


### PR DESCRIPTION
This pull request updates the addons search to only match the name of the addon. It also removes the `toString` method, since that's no longer needed.