### PR TITLE
feat: display addon budget from backend in dashboard

### DIFF
--- a/src/components/AddOnContainer.tsx
+++ b/src/components/AddOnContainer.tsx
@@ -23,7 +23,7 @@ function AddOnContainer(props: {
   const carBuyer = props.carBuyer;
   const addOns = props.addOns;
   const searchString = props.searchString;
-  const loanData = props.loanData
+  const loanData = props.loanData;
 
   return (
     <div className="shadow-xl z-10 p-4 flex flex-col gap-4 w-1/4 overflow-y-scroll">
@@ -33,8 +33,8 @@ function AddOnContainer(props: {
       <div className=" bg-blue-700 text-white text-center p-2 rounded mt-4">
         Add-Ons Budget{" "}
         <div className="text-white-900">
-                {"$"}
-                {loanData?.addOnBudget}
+          {"$"}
+          {loanData?.addOnBudget}
         </div>
       </div>
 

--- a/src/components/AddOnContainer.tsx
+++ b/src/components/AddOnContainer.tsx
@@ -14,6 +14,7 @@ function AddOnContainer(props: {
   car: Car | null;
   carBuyer: CarBuyer | null;
   addOns: AddOn[] | null;
+  loanData: LoanData | null;
   searchString: string | null;
   setSearchString: (s: string) => void;
   setLoanData: (c: LoanData) => void;
@@ -22,6 +23,7 @@ function AddOnContainer(props: {
   const carBuyer = props.carBuyer;
   const addOns = props.addOns;
   const searchString = props.searchString;
+  const loanData = props.loanData
 
   return (
     <div className="shadow-xl z-10 p-4 flex flex-col gap-4 w-1/4 overflow-y-scroll">
@@ -30,6 +32,10 @@ function AddOnContainer(props: {
       </div>
       <div className=" bg-blue-700 text-white text-center p-2 rounded mt-4">
         Add-Ons Budget{" "}
+        <div className="text-white-900">
+                {"$"}
+                {loanData?.addOnBudget}
+        </div>
       </div>
 
       <input

--- a/src/components/AddOnContainer.tsx
+++ b/src/components/AddOnContainer.tsx
@@ -30,14 +30,15 @@ function AddOnContainer(props: {
       <div className="text-center mt-4 text-2xl font-semibold">
         Available Add-Ons{" "}
       </div>
-      <div className=" bg-blue-700 text-white text-center p-2 rounded mt-4">
-        Add-Ons Budget{" "}
-        <div className="text-white-900">
-          {"$"}
-          {loanData?.addOnBudget}
+      {loanData && (
+        <div className="bg-blue-700 text-white text-center p-2 rounded mt-4">
+          Add-Ons Budget{" "}
+          <div className="text-white-900">
+            {"$"}
+            {loanData?.addOnBudget}
+          </div>
         </div>
-      </div>
-
+      )}
       <input
         type="search"
         placeholder="Search"

--- a/src/entities/LoanData.ts
+++ b/src/entities/LoanData.ts
@@ -10,6 +10,7 @@ export class LoanData {
   amount: number;
   term: number;
   interestSum: number;
+  addOnBudget: number;
 
   /**
    * Constructs a new LoanData object with the given values.
@@ -19,6 +20,7 @@ export class LoanData {
    * @param amount The loan amount
    * @param term The term length of the loan in months
    * @param interestSum The total added sum due to interest
+   * @param addOnBudget The budget for add ons
    */
   constructor(
     interestRate: number,
@@ -26,7 +28,8 @@ export class LoanData {
     sensoScore: string,
     amount: number,
     term: number,
-    interestSum: number
+    interestSum: number,
+    addOnBudget: number
   ) {
     this.interestRate = interestRate;
     this.installment = installment;
@@ -34,6 +37,7 @@ export class LoanData {
     this.amount = amount;
     this.term = term;
     this.interestSum = interestSum;
+    this.addOnBudget = addOnBudget;
   }
 
   /**
@@ -47,7 +51,8 @@ export class LoanData {
       json.sensoScore,
       json.amount,
       json.term,
-      json.interestSum
+      json.interestSum,
+      json.addOnBudget
     );
   }
 }
@@ -59,4 +64,5 @@ export type LoanDataJSON = {
   amount: number;
   term: number;
   interestSum: number;
+  addOnBudget: number;
 };

--- a/src/scenes/Dashboard.tsx
+++ b/src/scenes/Dashboard.tsx
@@ -78,13 +78,13 @@ function Dashboard() {
                 <span></span>
               </Link>
               <div className="flex gap-4">
-                <button className="bg-blue-800 h-full w-12 transition">
-                  <button
-                    className="rounded-lg overflow-x-auto h-8 "
-                    onClick={handleClick}
-                  >
+                <button
+                  className="bg-blue-800 h-full w-12 transition"
+                  onClick={handleClick}
+                >
+                  <div className="rounded-lg overflow-x-auto h-8">
                     {mode ? "🌙" : "☀️"}
-                  </button>
+                  </div>
                 </button>
               </div>
             </div>

--- a/src/scenes/Dashboard.tsx
+++ b/src/scenes/Dashboard.tsx
@@ -57,6 +57,7 @@ function Dashboard() {
             car={car}
             carBuyer={carBuyer}
             addOns={addOns}
+            loanData={loanData}
             searchString={searchString}
             setSearchString={setSearchString}
             setLoanData={setLoanData}

--- a/src/use-cases/fetchLoanData.ts
+++ b/src/use-cases/fetchLoanData.ts
@@ -11,7 +11,7 @@ export default async (carBuyer: CarBuyer, car: Car): Promise<LoanData> => {
   const res = await fetch(import.meta.env.VITE_BACKEND_BASE_URL + "/loan", {
     method: "POST",
     headers: { "Content-type": "application/json" },
-    body: JSON.stringify({ carBuyer: carBuyer, car: car }),
+    body: JSON.stringify({ carBuyer: carBuyer, car: car, loopMax: -1 }),
   });
 
   if (res.ok) {

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -101,7 +101,7 @@ describe("Loan Data", () => {
   let loanData: LoanData;
 
   beforeEach(() => {
-    loanData = new LoanData(1.25, 500, "Very Low", 10000, 36, 2000);
+    loanData = new LoanData(1.25, 500, "Very Low", 10000, 36, 2000, 5000);
   });
 
   it("can be created from the constructor", () => {
@@ -111,6 +111,7 @@ describe("Loan Data", () => {
     expect(loanData.amount).toBe(10000);
     expect(loanData.term).toBe(36);
     expect(loanData.interestSum).toBe(2000);
+    expect(loanData.addOnBudget).toBe(5000);
   });
 
   it("can be created from and stringified to JSON", () => {


### PR DESCRIPTION
This PR adds the functionality to display the add-on budget received from /loan requests in the dashboard page.
Right now, the loopMax parameter for /loan is set to -1, so the backend will loop calls to senso /rate until an error is returned, giving the maximum possible add-on budget, though this parameter is easy to change if we want to.
The add-on budget is added as an instance attribute for LoanData objects, just as it is in the backend.


Testing: Works on My Machine (TM)